### PR TITLE
feat/#94/원거리몬스터구현

### DIFF
--- a/roguelike/Assets/01_Scripts/Enemies/Projectile.cs
+++ b/roguelike/Assets/01_Scripts/Enemies/Projectile.cs
@@ -1,0 +1,92 @@
+using UnityEngine;
+
+/// <summary>
+/// 적 몬스터가 발사하는 투사체
+/// 플레이어를 향해 직선으로 날아가며 충돌 시 데미지를 줍니다.
+/// </summary>
+public class Projectile : MonoBehaviour
+{
+    #region Serialized Fields
+    
+    [Header("Projectile Settings")]
+    [SerializeField] private float speed = 5f;
+    [SerializeField] private float damage = 5f;
+    [SerializeField] private float lifetime = 3f; // 투사체 생존 시간
+    
+    #endregion
+    
+    #region Private Fields
+    
+    private Transform _target;
+    private Vector2 _moveDirection;
+    
+    #endregion
+    
+    #region Unity LifeCycle
+    
+    /// <summary>
+    /// 일정 시간 후에 스스로 파괴
+    /// </summary>
+    private void Start()
+    {
+        Destroy(gameObject, lifetime);
+    }
+
+    /// <summary>
+    /// 이동 실시간 조정
+    /// </summary>
+    private void Update()
+    {
+        transform.Translate(_moveDirection * (speed * Time.deltaTime), Space.World);
+    }
+    
+    #endregion
+    
+    #region Public Methods
+    
+    /// <summary>
+    /// 투사체를 발사할 때 호출, 목표 방향 설정
+    /// </summary>
+    /// <param name="target">추적할 타겟 (일반적으로 플레이어)</param>
+    public void Init(Transform target)
+    {
+        _target = target;
+        
+        if (_target != null)
+        {
+            Vector2 targetPos = _target.position;
+            Vector2 currentPos = transform.position;
+            
+            _moveDirection = (targetPos - currentPos).normalized;
+            
+            // 투사체 스프라이트 방향
+            float angle = Mathf.Atan2(_moveDirection.y, _moveDirection.x) * Mathf.Rad2Deg;
+            transform.rotation = Quaternion.Euler(0f, 0f, angle + 270);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+    
+    #endregion
+    
+    #region Private Methods
+    
+    /// <summary>
+    /// 플레이어와 충돌시 데미지 후 파괴
+    /// </summary>
+    /// <param name="other">충돌한 콜라이더</param>
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        PlayerManager player = other.GetComponent<PlayerManager>(); 
+
+        if (player != null)
+        {
+            player.TakeDamage(damage); 
+            Destroy(gameObject); 
+        }
+    }
+    
+    #endregion
+}

--- a/roguelike/Assets/01_Scripts/Enemies/Projectile.cs.meta
+++ b/roguelike/Assets/01_Scripts/Enemies/Projectile.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e524858d37a31142a50756fe2b35295

--- a/roguelike/Assets/01_Scripts/Enemies/RangedMonster.cs
+++ b/roguelike/Assets/01_Scripts/Enemies/RangedMonster.cs
@@ -1,0 +1,123 @@
+using UnityEngine;
+
+/// <summary>
+/// 원거리 공격을 하는 몬스터
+/// 일정 거리를 유지하며 투사체를 발사합니다.
+/// </summary>
+public class RangedMonster : Monster
+{
+    #region Serialized Fields
+    
+    [Header("Ranged Settings")]
+    [SerializeField] private float attackRange = 8.0f; // 공격을 시작할 거리
+    [SerializeField] private float fireRate = 3.0f; // 공격 주기
+    [SerializeField] private GameObject projectilePrefab; // 투사체 프리팹
+    
+    #endregion
+    
+    #region Private Fields
+    
+    private float _attackTimer;
+    
+    #endregion
+    
+    #region Unity LifeCycle
+    
+    protected override void Update()
+    {
+        if (_target != null)
+        {
+            // 이동 처리: 목표 거리보다 멀면 접근, 가까우면 멈춤
+            Move(_target.position);
+            
+            // 공격 처리: 공격 주기마다 투사체 발사
+            HandleAttack();
+        }
+    }
+    
+    #endregion
+
+    #region Public Methods
+    
+    /// <summary>
+    /// 타겟 위치로 이동 (공격 범위 밖이면 접근)
+    /// </summary>
+    /// <param name="targetPosition">목표 위치</param>
+    public override void Move(Vector2 targetPosition)
+    {
+        Vector2 currentPosition = transform.position;
+        float distance = Vector2.Distance(currentPosition, targetPosition);
+
+        // 플레이어와의 거리가 공격 범위보다 크면 접근
+        if (distance > attackRange)
+        {
+            transform.position = Vector2.MoveTowards(
+                currentPosition, 
+                targetPosition, 
+                moveSpeed * Time.deltaTime
+            );
+        }
+
+        // 스프라이트 좌우 반전
+        UpdateSpriteDirection(targetPosition);
+    }
+    
+    #endregion
+    
+    #region Private Methods
+    
+    /// <summary>
+    /// 공격 타이머를 관리하고 사격 가능 시 투사체 발사
+    /// </summary>
+    private void HandleAttack()
+    {
+        _attackTimer += Time.deltaTime;
+        
+        if (_target != null && 
+            Vector2.Distance(transform.position, _target.position) <= attackRange && 
+            _attackTimer >= fireRate)
+        {
+            ShootProjectile();
+            _attackTimer = 0f;
+        }
+    }
+
+    /// <summary>
+    /// 투사체를 생성하고 초기화
+    /// </summary>
+    private void ShootProjectile()
+    {
+        if (projectilePrefab == null) 
+        {
+            return;
+        }
+
+        // 투사체 생성
+        GameObject projObj = Instantiate(projectilePrefab, transform.position, Quaternion.identity);
+        Projectile projectile = projObj.GetComponent<Projectile>();
+
+        if (projectile != null)
+        {
+            // 투사체 초기화
+            projectile.Init(_target); 
+        }
+    }
+    
+    /// <summary>
+    /// 타겟 위치에 따라 스프라이트 방향 변경
+    /// </summary>
+    /// <param name="targetPosition">타겟 위치</param>
+    private void UpdateSpriteDirection(Vector2 targetPosition)
+    {
+        if (targetPosition.x < transform.position.x)
+        {
+            transform.localScale = new Vector3(-1, 1, 1);
+        }
+        else
+        {
+            transform.localScale = new Vector3(1, 1, 1);
+        }
+    }
+    
+    #endregion
+}

--- a/roguelike/Assets/01_Scripts/Enemies/RangedMonster.cs.meta
+++ b/roguelike/Assets/01_Scripts/Enemies/RangedMonster.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 32e729c387491944796ef7a053a8f3ff

--- a/roguelike/Assets/02_Prefabs/Enemies/Mobs/MonsterProjectile.prefab
+++ b/roguelike/Assets/02_Prefabs/Enemies/Mobs/MonsterProjectile.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &2355473164220929502
+--- !u!1 &128703109899176301
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,41 +8,55 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8880797221330917285}
-  - component: {fileID: 1239617161806971552}
-  - component: {fileID: 2754266992652824033}
-  - component: {fileID: 48254275233714998}
-  - component: {fileID: 1737600228348484724}
-  - component: {fileID: 6813797106969371374}
+  - component: {fileID: 2904064536553563204}
+  - component: {fileID: -6136489197034819759}
+  - component: {fileID: -1499766900028416198}
+  - component: {fileID: 6812364857601207734}
+  - component: {fileID: 7827061279219274638}
   m_Layer: 0
-  m_Name: Enemy
-  m_TagString: Enemy
+  m_Name: MonsterProjectile
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8880797221330917285
+--- !u!4 &2904064536553563204
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2355473164220929502}
+  m_GameObject: {fileID: 128703109899176301}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3, y: 3, z: 0}
+  m_LocalPosition: {x: 409.61874, y: 209.76323, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1239617161806971552
+--- !u!114 &-6136489197034819759
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 128703109899176301}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5e524858d37a31142a50756fe2b35295, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 2
+  damage: 5
+  lifetime: 3
+--- !u!212 &-1499766900028416198
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2355473164220929502}
+  m_GameObject: {fileID: 128703109899176301}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -80,39 +94,24 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2040353580739731165, guid: 60012e34675f9a44f9fb47bf6f0729f9, type: 3}
+  m_Sprite: {fileID: -1327499133, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
-  m_DrawMode: 1
-  m_Size: {x: 1, y: 1}
+  m_DrawMode: 0
+  m_Size: {x: 0.2777778, y: 0.5}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &2754266992652824033
-MonoBehaviour:
+--- !u!58 &6812364857601207734
+CircleCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2355473164220929502}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ceab619e76c4c3542aa87a86463cd2aa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maxHp: 10
-  moveSpeed: 2
-  expOrbPrefab: {fileID: 622782962632113181, guid: e0f17047d092c564ba65b11d0ea8c20b, type: 3}
---- !u!61 &48254275233714998
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2355473164220929502}
+  m_GameObject: {fileID: 128703109899176301}
   m_Enabled: 1
   serializedVersion: 3
   m_Density: 1
@@ -136,38 +135,28 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.8125, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 1
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!50 &1737600228348484724
+  m_Radius: 0.25
+--- !u!50 &7827061279219274638
 Rigidbody2D:
   serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2355473164220929502}
-  m_BodyType: 0
+  m_GameObject: {fileID: 128703109899176301}
+  m_BodyType: 1
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
   m_Mass: 1
   m_LinearDamping: 0
   m_AngularDamping: 0.05
-  m_GravityScale: 0
+  m_GravityScale: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -178,16 +167,4 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 4
---- !u!114 &6813797106969371374
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2355473164220929502}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f94e73f83aa11bb4fa9084d8c777c3d9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Constraints: 0

--- a/roguelike/Assets/02_Prefabs/Enemies/Mobs/MonsterProjectile.prefab.meta
+++ b/roguelike/Assets/02_Prefabs/Enemies/Mobs/MonsterProjectile.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 206f4a7f6b9e9414a8c909c3499a36eb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/roguelike/Assets/02_Prefabs/Enemies/Mobs/RangedMonster.prefab
+++ b/roguelike/Assets/02_Prefabs/Enemies/Mobs/RangedMonster.prefab
@@ -9,13 +9,13 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8880797221330917285}
+  - component: {fileID: 844969036950599132}
   - component: {fileID: 1239617161806971552}
-  - component: {fileID: 2754266992652824033}
   - component: {fileID: 48254275233714998}
   - component: {fileID: 1737600228348484724}
   - component: {fileID: 6813797106969371374}
   m_Layer: 0
-  m_Name: Enemy
+  m_Name: RangedMonster
   m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -36,6 +36,24 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &844969036950599132
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355473164220929502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 32e729c387491944796ef7a053a8f3ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHp: 7
+  moveSpeed: 1.5
+  expOrbPrefab: {fileID: 622782962632113181, guid: e0f17047d092c564ba65b11d0ea8c20b, type: 3}
+  attackRange: 3
+  fireRate: 3
+  projectilePrefab: {fileID: 128703109899176301, guid: 206f4a7f6b9e9414a8c909c3499a36eb, type: 3}
 --- !u!212 &1239617161806971552
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -80,9 +98,9 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2040353580739731165, guid: 60012e34675f9a44f9fb47bf6f0729f9, type: 3}
+  m_Sprite: {fileID: 1340294905846564614, guid: 69d2a1e37560a314a9239da3e4ea2b8a, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
+  m_FlipX: 1
   m_FlipY: 0
   m_DrawMode: 1
   m_Size: {x: 1, y: 1}
@@ -91,21 +109,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!114 &2754266992652824033
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2355473164220929502}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ceab619e76c4c3542aa87a86463cd2aa, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maxHp: 10
-  moveSpeed: 2
-  expOrbPrefab: {fileID: 622782962632113181, guid: e0f17047d092c564ba65b11d0ea8c20b, type: 3}
 --- !u!61 &48254275233714998
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -144,7 +147,7 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.8125, y: 1}
+    oldSize: {x: 0.29, y: 0.31}
     newSize: {x: 1, y: 1}
     adaptiveTilingThreshold: 0.5
     drawMode: 1

--- a/roguelike/Assets/02_Prefabs/Enemies/Mobs/RangedMonster.prefab.meta
+++ b/roguelike/Assets/02_Prefabs/Enemies/Mobs/RangedMonster.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 581c3aab06a034b4b86f43d19c09918c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
feat: 원거리몬스터 구현
일정 거리에서 멈추고 투사체 쏘는 것까지 테스트 되었습니다.
몬스터 회전하는거 고정시켰습니다.