### PR TITLE
feat: 구미호 보스 제작

### DIFF
--- a/roguelike/Assets/01_Scripts/Enemies/BossMonster.cs
+++ b/roguelike/Assets/01_Scripts/Enemies/BossMonster.cs
@@ -6,14 +6,8 @@ public class BossMonster : Monster
     {
         base.Start();
 
-        // 테스트로 알아보기 쉽게 크기를 키우고 빨간색으로 변경
+        // 테스트로 알아보기 쉽게 크기를 키움
         transform.localScale = Vector3.one * 2.0f; // 2배 커짐
-        
-        SpriteRenderer sr = GetComponent<SpriteRenderer>();
-        if (sr != null)
-        {
-            sr.color = Color.red; // 빨간색
-        }
     }
     
     public override void Move(Vector2 targetPosition)

--- a/roguelike/Assets/01_Scripts/Enemies/FoxBoss.cs
+++ b/roguelike/Assets/01_Scripts/Enemies/FoxBoss.cs
@@ -1,0 +1,276 @@
+using System.Collections;
+using UnityEngine;
+
+public class FoxBoss : BossMonster
+{
+    [Header("Pattern Settings")]
+    [SerializeField] private float patternInterval = 5f; // 패턴 사이 간격
+    [SerializeField] private float patternWarningTime = 1.5f; // 패턴 전조 시간
+
+    [Header("Pattern 1: 3-Way Shot")]
+    [SerializeField] private GameObject projectilePrefab;
+    [SerializeField] private float projectileSpeed = 7f; // 투사체 속도
+    [SerializeField] private float projectileSize = 1.0f; // 투사체 크기
+    [SerializeField] private float projectileDamage = 5f; // 투사체 데미지
+
+    [Header("Pattern 2: Dash")]
+    [SerializeField] private float dashDistance = 8f; // 대시 거리
+    [SerializeField] private float dashDuration = 0.5f; // 대시 지속 시간
+    [SerializeField] private float dashDamage = 10f; // 대시 데미지
+
+    [Header("Pattern 3: AOE Damage")]
+    [SerializeField] private float aoeDamage = 10f; // 범위공격 데미지
+    [SerializeField] private float aoeRange = 5f; // 범위공격 범위
+
+    private bool _isPatternActive = false;
+    private float _patternTimer = 0f;
+    private LineRenderer _lineRenderer;
+    private SpriteRenderer _rangeIndicator; // 원형 범위 표시용
+
+    protected override void Awake()
+    {
+        base.Awake();
+        
+        // 패턴 범위 표시용 ( 추후 스프라이트로 변경 가능)
+        
+        // LineRenderer 설정 (대시 경로 표시용)
+        _lineRenderer = gameObject.AddComponent<LineRenderer>();
+        _lineRenderer.startWidth = 0.1f;
+        _lineRenderer.endWidth = 0.1f;
+        _lineRenderer.material = new Material(Shader.Find("Sprites/Default"));
+        _lineRenderer.startColor = new Color(1, 0, 0, 0.5f);
+        _lineRenderer.endColor = new Color(1, 0, 0, 0.5f);
+        _lineRenderer.enabled = false;
+
+        // 범위 표시용 SpriteRenderer 
+        GameObject indicatorObj = new GameObject("RangeIndicator");
+        indicatorObj.transform.SetParent(transform);
+        indicatorObj.transform.localPosition = Vector3.zero;
+        _rangeIndicator = indicatorObj.AddComponent<SpriteRenderer>();
+        Destroy(indicatorObj); 
+    }
+
+    protected override void Start()
+    {
+        base.Start();
+        _patternTimer = patternInterval;
+    }
+
+    protected override void Update()
+    {
+        if (_isPatternActive) return;
+
+        // 평소에는 플레이어 추적
+        base.Update();
+
+        _patternTimer -= Time.deltaTime;
+        if (_patternTimer <= 0)
+        {
+            StartCoroutine(ExecuteRandomPattern());
+        }
+    }
+
+    private IEnumerator ExecuteRandomPattern()
+    {
+        _isPatternActive = true;
+        
+        // 패턴 랜덤 선택 
+        int patternIndex = Random.Range(0, 3);
+        
+        // 패턴 시작 전 멈춤
+        // Move()가 호출되지 않으므로 제자리에 멈춤 (Rigidbody velocity가 있다면 0으로 초기화 필요)
+        Rigidbody2D rb = GetComponent<Rigidbody2D>();
+        if (rb != null) rb.linearVelocity = Vector2.zero;
+
+        switch (patternIndex)
+        {
+            case 0:
+                yield return StartCoroutine(Pattern_ThreeWayShot());
+                break;
+            case 1:
+                yield return StartCoroutine(Pattern_Dash());
+                break;
+            case 2:
+                yield return StartCoroutine(Pattern_AOEDamage());
+                break;
+        }
+
+        _isPatternActive = false;
+        _patternTimer = patternInterval;
+    }
+
+    // 패턴 1: 3갈래 투사체 발사
+    private IEnumerator Pattern_ThreeWayShot()
+    {
+        Debug.Log("FoxBoss: 3-Way Shot Pattern Start");
+
+        // 전조: 플레이어 방향으로 3갈래 선 표시
+        Vector2 savedDirection = Vector2.right; 
+        if (_target != null)
+        {
+            savedDirection = (_target.position - transform.position).normalized;
+            ShowTelegraphLines(savedDirection, 3, 30f); 
+        }
+
+        yield return new WaitForSeconds(patternWarningTime);
+
+        HideTelegraph();
+
+        // 저장된 방향으로 발사 
+        if (projectilePrefab != null)
+        {
+            FireProjectile(savedDirection); 
+            FireProjectile(Quaternion.Euler(0, 0, 30) * savedDirection); 
+            FireProjectile(Quaternion.Euler(0, 0, -30) * savedDirection); 
+        }
+    }
+
+    private void FireProjectile(Vector2 direction)
+    {
+        GameObject projObj = Instantiate(projectilePrefab, transform.position, Quaternion.identity);
+        Projectile2 proj = projObj.GetComponent<Projectile2>();
+        if (proj != null)
+        {
+            proj.SetSize(projectileSize);
+            proj.SetSpeed(projectileSpeed);
+            proj.SetDamage(projectileDamage);
+            proj.Init(direction);
+        }
+    }
+
+    // 패턴 2: 돌진
+    private IEnumerator Pattern_Dash()
+    {
+        Debug.Log("FoxBoss: Dash Pattern Start");
+
+        // 플레이어 방향으로 일정 거리만큼 대시
+        Vector2 dashDirection = Vector2.right; 
+        if (_target != null)
+        {
+            dashDirection = (_target.position - transform.position).normalized;
+        }
+        
+        Vector2 startPos = transform.position;
+        Vector2 dashTargetPos = startPos + dashDirection * dashDistance;
+
+        // 전조: 돌진 경로 표시
+        _lineRenderer.enabled = true;
+        _lineRenderer.positionCount = 2;
+        _lineRenderer.SetPosition(0, startPos);
+        _lineRenderer.SetPosition(1, dashTargetPos);
+
+        yield return new WaitForSeconds(patternWarningTime);
+
+        _lineRenderer.enabled = false;
+
+        // 돌진 실행
+        float elapsedTime = 0f;
+        
+        while (elapsedTime < dashDuration)
+        {
+            transform.position = Vector2.Lerp(startPos, dashTargetPos, elapsedTime / dashDuration);
+            elapsedTime += Time.deltaTime;
+            yield return null;
+        }
+        transform.position = dashTargetPos;
+        
+        // 대시 중 플레이어와 충돌했는지 체크 (범위 내에 있으면 데미지)
+        if (_target != null)
+        {
+            float distance = Vector2.Distance(transform.position, _target.position);
+            if (distance <= 1.5f) // 대시 충돌 범위
+            {
+                PlayerManager player = _target.GetComponent<PlayerManager>();
+                if (player != null)
+                {
+                    player.TakeDamage(dashDamage);
+                    Debug.Log($"FoxBoss: Player hit by Dash for {dashDamage} damage!");
+                }
+            }
+        }
+    }
+
+
+
+    // 여러 갈래 선 그리기
+    private void ShowTelegraphLines(Vector2 centerDir, int count, float angleSpacing)
+    {
+        _lineRenderer.enabled = true;
+        _lineRenderer.positionCount = 7; 
+
+        float lineLength = 10f;
+        Vector3 bossPos = transform.position;
+
+        // 중앙 선
+        _lineRenderer.SetPosition(0, bossPos);
+        _lineRenderer.SetPosition(1, bossPos + (Vector3)centerDir * lineLength);
+        
+        // 보스 위치로 돌아옴
+        _lineRenderer.SetPosition(2, bossPos);
+
+        // 왼쪽 선 (+30도)
+        Vector2 leftDir = Quaternion.Euler(0, 0, angleSpacing) * centerDir;
+        _lineRenderer.SetPosition(3, bossPos + (Vector3)leftDir * lineLength);
+        
+        // 보스 위치로 돌아옴
+        _lineRenderer.SetPosition(4, bossPos);
+
+        // 오른쪽 선 (-30도)
+        Vector2 rightDir = Quaternion.Euler(0, 0, -angleSpacing) * centerDir;
+        _lineRenderer.SetPosition(5, bossPos + (Vector3)rightDir * lineLength);
+        
+        // 다시 보스 위치로 
+        _lineRenderer.SetPosition(6, bossPos);
+    }
+
+    private void HideTelegraph()
+    {
+        _lineRenderer.enabled = false;
+    }
+
+    // 패턴 3: 범위 피해
+    private IEnumerator Pattern_AOEDamage()
+    {
+        Debug.Log("FoxBoss: AOE Damage Pattern Start");
+
+        // 전조: 주변 원형 범위 표시
+        DrawCircle(aoeRange);
+
+        yield return new WaitForSeconds(patternWarningTime);
+
+        _lineRenderer.enabled = false;
+
+        // 범위 내 플레이어 체크 및 피해
+        if (_target != null)
+        {
+            float distance = Vector2.Distance(transform.position, _target.position);
+            if (distance <= aoeRange)
+            {
+                PlayerManager player = _target.GetComponent<PlayerManager>();
+                if (player != null)
+                {
+                    player.TakeDamage(aoeDamage);
+                    Debug.Log($"FoxBoss: Player hit by AOE for {aoeDamage} damage!");
+                }
+            }
+        }
+    }
+
+    private void DrawCircle(float radius)
+    {
+        _lineRenderer.enabled = true;
+        int segments = 50;
+        _lineRenderer.positionCount = segments + 1;
+        float angle = 0f;
+
+        for (int i = 0; i < segments + 1; i++)
+        {
+            float x = Mathf.Sin(Mathf.Deg2Rad * angle) * radius;
+            float y = Mathf.Cos(Mathf.Deg2Rad * angle) * radius;
+
+            _lineRenderer.SetPosition(i, transform.position + new Vector3(x, y, 0));
+
+            angle += (360f / segments);
+        }
+    }
+}

--- a/roguelike/Assets/01_Scripts/Enemies/FoxBoss.cs.meta
+++ b/roguelike/Assets/01_Scripts/Enemies/FoxBoss.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 591af15502d307249b395eb5f77c2f76

--- a/roguelike/Assets/01_Scripts/Enemies/Projectile2.cs
+++ b/roguelike/Assets/01_Scripts/Enemies/Projectile2.cs
@@ -47,7 +47,6 @@ public class Projectile2 : MonoBehaviour
     /// <summary>
     /// 투사체를 발사할 때 호출, 목표 방향 설정
     /// </summary>
-    /// <param name="target">추적할 타겟 (일반적으로 플레이어)</param>
     public void Init(Transform target)
     {
         _target = target;
@@ -59,24 +58,61 @@ public class Projectile2 : MonoBehaviour
             
             _moveDirection = (targetPos - currentPos).normalized;
             
-            // 투사체 스프라이트 방향
-            float angle = Mathf.Atan2(_moveDirection.y, _moveDirection.x) * Mathf.Rad2Deg;
-            transform.rotation = Quaternion.Euler(0f, 0f, angle + 270);
+            UpdateRotation();
         }
         else
         {
             Destroy(gameObject);
         }
     }
+
+    /// <summary>
+    /// 방향 벡터로 초기화
+    /// </summary>
+    public void Init(Vector2 direction)
+    {
+        _moveDirection = direction.normalized;
+        UpdateRotation();
+    }
+
+    /// <summary>
+    /// 투사체 크기 설정
+    /// </summary>
+    public void SetSize(float scale)
+    {
+        transform.localScale = Vector3.one * scale;
+    }
+
+    /// <summary>
+    /// 투사체 속도 설정
+    /// </summary>
+    public void SetSpeed(float newSpeed)
+    {
+        speed = newSpeed;
+    }
+
+    /// <summary>
+    /// 투사체 데미지 설정
+    /// </summary>
+    public void SetDamage(float newDamage)
+    {
+        damage = newDamage;
+    }
     
     #endregion
     
     #region Private Methods
+
+    private void UpdateRotation()
+    {
+        // 투사체 스프라이트 방향
+        float angle = Mathf.Atan2(_moveDirection.y, _moveDirection.x) * Mathf.Rad2Deg;
+        transform.rotation = Quaternion.Euler(0f, 0f, angle + 270);
+    }
     
     /// <summary>
     /// 플레이어와 충돌시 데미지 후 파괴
     /// </summary>
-    /// <param name="other">충돌한 콜라이더</param>
     private void OnTriggerEnter2D(Collider2D other)
     {
         PlayerManager player = other.GetComponent<PlayerManager>(); 

--- a/roguelike/Assets/02_Prefabs/Enemies/Bosses/FoxBoss.prefab
+++ b/roguelike/Assets/02_Prefabs/Enemies/Bosses/FoxBoss.prefab
@@ -1,0 +1,225 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2355473164220929502
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8880797221330917285}
+  - component: {fileID: -580824824227003035}
+  - component: {fileID: 1239617161806971552}
+  - component: {fileID: 48254275233714998}
+  - component: {fileID: 1737600228348484724}
+  - component: {fileID: 6813797106969371374}
+  - component: {fileID: 3305980863821901834}
+  m_Layer: 0
+  m_Name: FoxBoss
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8880797221330917285
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355473164220929502}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3, y: 3, z: 0}
+  m_LocalScale: {x: 1.2, y: 1.2, z: 1.2}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-580824824227003035
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355473164220929502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 591af15502d307249b395eb5f77c2f76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHp: 100
+  moveSpeed: 1.2
+  expOrbPrefab: {fileID: 622782962632113181, guid: e0f17047d092c564ba65b11d0ea8c20b, type: 3}
+  patternInterval: 3
+  patternWarningTime: 1.2
+  projectilePrefab: {fileID: 128703109899176301, guid: 206f4a7f6b9e9414a8c909c3499a36eb, type: 3}
+  projectileSpeed: 15
+  projectileSize: 2.5
+  dashDistance: 7
+  dashDuration: 0.5
+  aoeDamage: 10
+  aoeRange: 5
+--- !u!212 &1239617161806971552
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355473164220929502}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -4702544020559098553, guid: e51173c1be343e14cb57fd08e627a7a3, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 1
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &48254275233714998
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355473164220929502}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.9375, y: 0.59375}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 1
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!50 &1737600228348484724
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355473164220929502}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!114 &6813797106969371374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355473164220929502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f94e73f83aa11bb4fa9084d8c777c3d9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!95 &3305980863821901834
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355473164220929502}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 074f2c5e67e7d3f468d536c49ddeb9b7, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0

--- a/roguelike/Assets/02_Prefabs/Enemies/Bosses/FoxBoss.prefab.meta
+++ b/roguelike/Assets/02_Prefabs/Enemies/Bosses/FoxBoss.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 721093c7e785e5b438ad80e165d569da
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
BossMonster.cs : 보스 빨간색 표시 제거
Projectile2.cs : 투사체를 여러 몬스터가 사용할 수 있도록 변경
FoxBoss.cs : 3가지 패턴(3갈래 투사체, 돌진, 주변 범위 공격) 구현해서 보스 제작 / 패턴 순서는 랜덤 / 패턴 범위 현재 선으로 표시 중

* 플레이어가 입력하는 방향키를 반대로 만드는 매혹 패턴도 생각해봤는데 PlayerManager를 건드려야해서 일단 보류 했습니다.