### PR TITLE
refactor : 장산범보스 / 충돌 데미지 및 몬스터 관련 수정

### DIFF
--- a/roguelike/Assets/01_Scripts/Enemies/FoxBoss.cs
+++ b/roguelike/Assets/01_Scripts/Enemies/FoxBoss.cs
@@ -47,7 +47,10 @@ public class FoxBoss : BossMonster
         indicatorObj.transform.SetParent(transform);
         indicatorObj.transform.localPosition = Vector3.zero;
         _rangeIndicator = indicatorObj.AddComponent<SpriteRenderer>();
-        Destroy(indicatorObj); 
+        // 사각형 스프라이트 생성 (원 대신 사각형 사용)
+        _rangeIndicator.sprite = CreateCircleSprite();
+        _rangeIndicator.color = new Color(1, 0, 0, 0.3f); // 빨간색 반투명
+        _rangeIndicator.enabled = false;
     }
 
     protected override void Start()
@@ -174,20 +177,7 @@ public class FoxBoss : BossMonster
         }
         transform.position = dashTargetPos;
         
-        // 대시 중 플레이어와 충돌했는지 체크 (범위 내에 있으면 데미지)
-        if (_target != null)
-        {
-            float distance = Vector2.Distance(transform.position, _target.position);
-            if (distance <= 1.5f) // 대시 충돌 범위
-            {
-                PlayerManager player = _target.GetComponent<PlayerManager>();
-                if (player != null)
-                {
-                    player.TakeDamage(dashDamage);
-                    Debug.Log($"FoxBoss: Player hit by Dash for {dashDamage} damage!");
-                }
-            }
-        }
+        // 대시 데미지는 충돌 데미지 시스템으로 처리됨 (Monster.OnCollisionStay2D)
     }
 
 
@@ -233,12 +223,12 @@ public class FoxBoss : BossMonster
     {
         Debug.Log("FoxBoss: AOE Damage Pattern Start");
 
-        // 전조: 주변 원형 범위 표시
-        DrawCircle(aoeRange);
+        // 전조: 주변 원형 범위 표시 (채워진 원)
+        ShowFilledCircle(aoeRange);
 
         yield return new WaitForSeconds(patternWarningTime);
 
-        _lineRenderer.enabled = false;
+        HideFilledCircle();
 
         // 범위 내 플레이어 체크 및 피해
         if (_target != null)
@@ -256,21 +246,50 @@ public class FoxBoss : BossMonster
         }
     }
 
-    private void DrawCircle(float radius)
+    /// <summary>
+    /// 원형 스프라이트를 생성합니다.
+    /// </summary>
+    private Sprite CreateCircleSprite()
     {
-        _lineRenderer.enabled = true;
-        int segments = 50;
-        _lineRenderer.positionCount = segments + 1;
-        float angle = 0f;
-
-        for (int i = 0; i < segments + 1; i++)
+        int resolution = 128;
+        Texture2D texture = new Texture2D(resolution, resolution);
+        Color[] pixels = new Color[resolution * resolution];
+        
+        Vector2 center = new Vector2(resolution / 2f, resolution / 2f);
+        float radius = resolution / 2f;
+        
+        for (int y = 0; y < resolution; y++)
         {
-            float x = Mathf.Sin(Mathf.Deg2Rad * angle) * radius;
-            float y = Mathf.Cos(Mathf.Deg2Rad * angle) * radius;
-
-            _lineRenderer.SetPosition(i, transform.position + new Vector3(x, y, 0));
-
-            angle += (360f / segments);
+            for (int x = 0; x < resolution; x++)
+            {
+                float distance = Vector2.Distance(new Vector2(x, y), center);
+                pixels[y * resolution + x] = distance <= radius ? Color.white : Color.clear;
+            }
         }
+        
+        texture.SetPixels(pixels);
+        texture.Apply();
+        
+        return Sprite.Create(texture, new Rect(0, 0, resolution, resolution), new Vector2(0.5f, 0.5f), resolution / 2f);
     }
+    
+    /// <summary>
+    /// 채워진 원을 표시합니다.
+    /// </summary>
+    private void ShowFilledCircle(float radius)
+    {
+        _rangeIndicator.enabled = true;
+        // 스프라이트의 기본 크기가 2 유닛(지름)이므로, 원하는 반지름에 맞게 스케일 조정
+        _rangeIndicator.transform.localScale = Vector3.one * radius;
+    }
+    
+    /// <summary>
+    /// 채워진 원을 숨깁니다.
+    /// </summary>
+    private void HideFilledCircle()
+    {
+        _rangeIndicator.enabled = false;
+    }
+    
+    // 기존 DrawCircle 메서드는 더 이상 사용하지 않음
 }

--- a/roguelike/Assets/01_Scripts/Enemies/JangsanTigerBoss.cs
+++ b/roguelike/Assets/01_Scripts/Enemies/JangsanTigerBoss.cs
@@ -1,0 +1,285 @@
+using System.Collections;
+using UnityEngine;
+
+public class JangsanTigerBoss : BossMonster
+{
+    [Header("Pattern Settings")]
+    [SerializeField] private float patternInterval = 5f; // 패턴 사이 간격
+    [SerializeField] private float patternWarningTime = 1f; // 패턴 전조 시간
+
+    [Header("Pattern 1: Teleport Dash")]
+    [SerializeField] private float teleportDashSpeed = 10f; // 순간이동 후 돌진 속도
+    [SerializeField] private float teleportDashDistance = 6f; // 돌진 거리
+    [SerializeField] private float fadeOutDuration = 1f; // 페이드아웃 시간
+    [SerializeField] private float fadeInDuration = 0.2f; // 페이드인 시간
+
+    [Header("Pattern 2: Cross & X Barrage")]
+    [SerializeField] private GameObject projectilePrefab;
+    [SerializeField] private float projectileSpeed = 7f;
+    [SerializeField] private float projectileSize = 1.0f;
+    [SerializeField] private float projectileDamage = 5f;
+    [SerializeField] private int barrageCount = 4; // 발사 횟수
+    [SerializeField] private float barrageInterval = 0.3f; // 발사 간격
+
+    [Header("Pattern 3: Inertia Chase")]
+    [SerializeField] private float inertiaChaseMaxSpeed = 12f; // 최대 속도
+    [SerializeField] private float inertiaChaseAcceleration = 15f; // 가속도
+    [SerializeField] private float inertiaChaseRotationSpeed = 2f; // 회전 속도 (관성 표현)
+    [SerializeField] private float inertiaChaseDuration = 3.5f; // 추격 지속 시간
+
+    private bool _isPatternActive = false;
+    private float _patternTimer = 0f;
+    private SpriteRenderer _spriteRenderer;
+    private Vector2 _currentVelocity = Vector2.zero; // 관성 추격용 속도 벡터
+
+    protected override void Awake()
+    {
+        base.Awake();
+        _spriteRenderer = GetComponent<SpriteRenderer>();
+    }
+
+    protected override void Start()
+    {
+        base.Start();
+        _patternTimer = patternInterval;
+    }
+
+    protected override void Update()
+    {
+        if (_isPatternActive) return;
+
+        // 평소에는 플레이어 추적
+        base.Update();
+
+        _patternTimer -= Time.deltaTime;
+        if (_patternTimer <= 0)
+        {
+            StartCoroutine(ExecuteRandomPattern());
+        }
+    }
+
+    private IEnumerator ExecuteRandomPattern()
+    {
+        _isPatternActive = true;
+
+        // 패턴 랜덤 선택 (3가지)
+        int patternIndex = Random.Range(0, 3);
+
+        // 패턴 시작 전 멈춤
+        Rigidbody2D rb = GetComponent<Rigidbody2D>();
+        if (rb != null) rb.linearVelocity = Vector2.zero;
+
+        switch (patternIndex)
+        {
+            case 0:
+                yield return StartCoroutine(Pattern_TeleportDash());
+                break;
+            case 1:
+                yield return StartCoroutine(Pattern_CrossXBarrage());
+                break;
+            case 2:
+                yield return StartCoroutine(Pattern_InertiaChase());
+                break;
+        }
+
+        _isPatternActive = false;
+        _patternTimer = patternInterval;
+    }
+
+    // 패턴 1: 순간이동 돌진
+    private IEnumerator Pattern_TeleportDash()
+    {
+        Debug.Log("JangsanTiger: Teleport Dash Pattern Start");
+
+        // 1. 페이드 아웃 
+        yield return StartCoroutine(FadeOut(fadeOutDuration));
+
+        // 2. 플레이어 뒤로 순간이동
+        if (_target != null)
+        {
+            TeleportBehindPlayer();
+        }
+
+        // 3. 페이드 인 
+        yield return StartCoroutine(FadeIn(fadeInDuration));
+
+        // 4. 플레이어를 향해 돌진
+        if (_target != null)
+        {
+            Vector2 dashDirection = (_target.position - transform.position).normalized;
+            Vector2 startPos = transform.position;
+            Vector2 dashTargetPos = startPos + dashDirection * teleportDashDistance;
+
+            float dashDuration = teleportDashDistance / teleportDashSpeed;
+            float elapsedTime = 0f;
+
+            while (elapsedTime < dashDuration)
+            {
+                transform.position = Vector2.Lerp(startPos, dashTargetPos, elapsedTime / dashDuration);
+                elapsedTime += Time.deltaTime;
+                yield return null;
+            }
+            transform.position = dashTargetPos;
+        }
+    }
+
+    // 패턴 2: 십자/X 투사체
+    private IEnumerator Pattern_CrossXBarrage()
+    {
+        Debug.Log("JangsanTiger: Cross & X Barrage Pattern Start");
+
+        // 전조
+        yield return new WaitForSeconds(patternWarningTime);
+
+        // 반복: 십자 -> X -> 십자 -> X
+        for (int i = 0; i < barrageCount; i++)
+        {
+            if (i % 2 == 0)
+            {
+                // 홀수 회차: 십자(+)
+                FireProjectilesInCross();
+            }
+            else
+            {
+                // 짝수 회차: X(×)
+                FireProjectilesInX();
+            }
+
+            yield return new WaitForSeconds(barrageInterval);
+        }
+    }
+
+    // 패턴 3: 관성 추격
+    private IEnumerator Pattern_InertiaChase()
+    {
+        Debug.Log("JangsanTiger: Inertia Chase Pattern Start");
+
+        // 1. 1초 정지 (전조)
+        yield return new WaitForSeconds(patternWarningTime);
+
+        // 2. 관성 추격 시작
+        _currentVelocity = Vector2.zero;
+        float elapsedTime = 0f;
+
+        while (elapsedTime < inertiaChaseDuration)
+        {
+            if (_target != null)
+            {
+                // 목표 방향 계산
+                Vector2 targetDirection = (_target.position - transform.position).normalized;
+
+                // 현재 속도 방향과 목표 방향을 보간 (관성 효과)
+                Vector2 desiredVelocity = targetDirection * inertiaChaseMaxSpeed;
+                _currentVelocity = Vector2.Lerp(_currentVelocity, desiredVelocity, 
+                    inertiaChaseRotationSpeed * Time.deltaTime);
+
+                // 최대 속도 제한
+                if (_currentVelocity.magnitude > inertiaChaseMaxSpeed)
+                {
+                    _currentVelocity = _currentVelocity.normalized * inertiaChaseMaxSpeed;
+                }
+
+                // 이동
+                transform.position = (Vector2)transform.position + _currentVelocity * Time.deltaTime;
+            }
+
+            elapsedTime += Time.deltaTime;
+            yield return null;
+        }
+
+        // 3. 급감속
+        float decelerationTime = 0.5f;
+        float decelerationElapsed = 0f;
+
+        while (decelerationElapsed < decelerationTime)
+        {
+            _currentVelocity = Vector2.Lerp(_currentVelocity, Vector2.zero, 
+                decelerationElapsed / decelerationTime);
+            transform.position = (Vector2)transform.position + _currentVelocity * Time.deltaTime;
+
+            decelerationElapsed += Time.deltaTime;
+            yield return null;
+        }
+
+        _currentVelocity = Vector2.zero;
+    }
+
+    // === 헬퍼 메서드 ===
+
+    private IEnumerator FadeOut(float duration)
+    {
+        float elapsedTime = 0f;
+        Color originalColor = _spriteRenderer.color;
+
+        while (elapsedTime < duration)
+        {
+            float alpha = Mathf.Lerp(1f, 0f, elapsedTime / duration);
+            _spriteRenderer.color = new Color(originalColor.r, originalColor.g, originalColor.b, alpha);
+            elapsedTime += Time.deltaTime;
+            yield return null;
+        }
+
+        _spriteRenderer.color = new Color(originalColor.r, originalColor.g, originalColor.b, 0f);
+    }
+
+    private IEnumerator FadeIn(float duration)
+    {
+        float elapsedTime = 0f;
+        Color originalColor = _spriteRenderer.color;
+
+        while (elapsedTime < duration)
+        {
+            float alpha = Mathf.Lerp(0f, 1f, elapsedTime / duration);
+            _spriteRenderer.color = new Color(originalColor.r, originalColor.g, originalColor.b, alpha);
+            elapsedTime += Time.deltaTime;
+            yield return null;
+        }
+
+        _spriteRenderer.color = new Color(originalColor.r, originalColor.g, originalColor.b, 1f);
+    }
+
+    private void TeleportBehindPlayer()
+    {
+        if (_target == null) return;
+
+        // 플레이어의 반대 방향으로 2.5 유닛 거리
+        PlayerManager player = _target.GetComponent<PlayerManager>();
+        Vector2 playerFacingDirection = player != null ? player.FacingDirection : Vector2.right;
+        
+        Vector2 behindPosition = (Vector2)_target.position - playerFacingDirection * 2.5f;
+        transform.position = behindPosition;
+    }
+
+    private void FireProjectilesInCross()
+    {
+        // 상하좌우 
+        FireProjectile(Vector2.up);
+        FireProjectile(Vector2.down);
+        FireProjectile(Vector2.left);
+        FireProjectile(Vector2.right);
+    }
+
+    private void FireProjectilesInX()
+    {
+        // 대각선
+        FireProjectile(new Vector2(1, 1).normalized);
+        FireProjectile(new Vector2(1, -1).normalized);
+        FireProjectile(new Vector2(-1, 1).normalized);
+        FireProjectile(new Vector2(-1, -1).normalized);
+    }
+
+    private void FireProjectile(Vector2 direction)
+    {
+        if (projectilePrefab == null) return;
+
+        GameObject projObj = Instantiate(projectilePrefab, transform.position, Quaternion.identity);
+        Projectile2 proj = projObj.GetComponent<Projectile2>();
+        if (proj != null)
+        {
+            proj.SetSize(projectileSize);
+            proj.SetSpeed(projectileSpeed);
+            proj.SetDamage(projectileDamage);
+            proj.Init(direction);
+        }
+    }
+}

--- a/roguelike/Assets/01_Scripts/Enemies/JangsanTigerBoss.cs.meta
+++ b/roguelike/Assets/01_Scripts/Enemies/JangsanTigerBoss.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 32c2ba6689cc5b54e9a08e1d1f3c2837

--- a/roguelike/Assets/01_Scripts/Enemies/Monster.cs
+++ b/roguelike/Assets/01_Scripts/Enemies/Monster.cs
@@ -9,6 +9,7 @@ public abstract class Monster : MonoBehaviour
 
     [Header("Stats")] [SerializeField] protected float maxHp = 10f;
     [SerializeField] protected float moveSpeed = 2f;
+    [SerializeField] protected float contactDamage = 5f; // 플레이어와 충돌 시 데미지
 
     #endregion
 
@@ -159,5 +160,22 @@ public abstract class Monster : MonoBehaviour
     }
 
     #endregion
-   
+    
+    #region Collision
+    
+    /// <summary>
+    /// 플레이어와 충돌 중일 때 데미지를 줍니다.
+    /// </summary>
+    protected virtual void OnCollisionStay2D(Collision2D collision)
+    {
+        // 플레이어와 충돌 확인
+        PlayerManager player = collision.gameObject.GetComponent<PlayerManager>();
+        if (player != null)
+        {
+            // 충돌 데미지 적용 (무적 시스템이 자동으로 처리)
+            player.TakeDamage(contactDamage, true);
+        }
+    }
+    
+    #endregion
 }

--- a/roguelike/Assets/01_Scripts/Player/PlayerManager.cs
+++ b/roguelike/Assets/01_Scripts/Player/PlayerManager.cs
@@ -42,6 +42,9 @@ public class PlayerManager : MonoBehaviour
 
     // (Sprint 2 추가) 바라보는 방향 (기본값: 오른쪽)
     public Vector2 FacingDirection { get; private set; } = Vector2.right;
+    
+    // 충돌 데미지 무적 상태 확인
+    public bool IsInvincibleFromContact => _contactDamageTimer > 0f;
     #endregion
     
     #region Serialized Fields
@@ -54,6 +57,10 @@ public class PlayerManager : MonoBehaviour
     [Header("Stats")]
     [SerializeField]
     private PlayerStats stats;
+    
+    [Header("Contact Damage Settings")]
+    [SerializeField]
+    private float contactDamageCooldown = 1f; // 충돌 데미지 쿨다운 (무적시간)
     #endregion
 
     #region Private Fields
@@ -69,6 +76,9 @@ public class PlayerManager : MonoBehaviour
     private int _maxExp = 100; // 초기 최대 경험치
     private int _gold = 0;
     private int _killCount = 0;
+    
+    // --- 충돌 데미지 관련 ---
+    private float _contactDamageTimer = 0f; // 충돌 데미지 쿨다운 타이머
     #endregion
 
     #region Unity LifeCycle
@@ -85,6 +95,12 @@ public class PlayerManager : MonoBehaviour
     private void Update()
     {
         Player_Animation();
+        
+        // 충돌 데미지 쿨다운 타이머 감소
+        if (_contactDamageTimer > 0f)
+        {
+            _contactDamageTimer -= Time.deltaTime;
+        }
     }
     private void Start()
     {
@@ -174,9 +190,31 @@ public class PlayerManager : MonoBehaviour
     /// <param name="amount">받은 데미지 양</param>
     public void TakeDamage(float amount)
     {
+        TakeDamage(amount, false);
+    }
+    
+    /// <summary>
+    /// 캐릭터의 HP를 감소시킵니다. 충돌 데미지 여부를 지정할 수 있습니다.
+    /// </summary>
+    /// <param name="amount">받은 데미지 양</param>
+    /// <param name="isContactDamage">몬스터 충돌 데미지인지 여부</param>
+    public void TakeDamage(float amount, bool isContactDamage)
+    {
         if (_currentHp <= 0) return; // 이미 사망함
+        
+        // 충돌 데미지이고 무적 상태라면 무시
+        if (isContactDamage && IsInvincibleFromContact)
+        {
+            return;
+        }
 
         _currentHp -= amount;
+        
+        // 충돌 데미지를 받았다면 쿨다운 타이머 설정
+        if (isContactDamage)
+        {
+            _contactDamageTimer = contactDamageCooldown;
+        }
 
         // (Sprint 1, B-1.a) HP가 변경되었음을 모든 구독자(HUDManager 등)에게 "방송"
         OnHpChanged?.Invoke(_currentHp, stats.MaxHp);

--- a/roguelike/Assets/02_Prefabs/Enemies/Bosses/FoxBoss.prefab
+++ b/roguelike/Assets/02_Prefabs/Enemies/Bosses/FoxBoss.prefab
@@ -51,18 +51,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxHp: 100
   moveSpeed: 1.2
+  contactDamage: 20
   expOrbPrefab: {fileID: 622782962632113181, guid: e0f17047d092c564ba65b11d0ea8c20b, type: 3}
   patternInterval: 3
   patternWarningTime: 1.2
   projectilePrefab: {fileID: 128703109899176301, guid: 206f4a7f6b9e9414a8c909c3499a36eb, type: 3}
-  projectileSpeed: 15
-  projectileSize: 2.5
-  projectileDamage: 5
+  projectileSpeed: 10
+  projectileSize: 2
+  projectileDamage: 10
   dashDistance: 7
   dashDuration: 0.5
-  dashDamage: 10
+  dashDamage: 20
   aoeDamage: 10
-  aoeRange: 5
+  aoeRange: 2.5
 --- !u!212 &1239617161806971552
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -148,7 +149,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
@@ -172,7 +173,7 @@ Rigidbody2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2355473164220929502}
-  m_BodyType: 0
+  m_BodyType: 1
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0

--- a/roguelike/Assets/02_Prefabs/Enemies/Bosses/TigerBoss.prefab
+++ b/roguelike/Assets/02_Prefabs/Enemies/Bosses/TigerBoss.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &128703109899176301
+--- !u!1 &2355473164220929502
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,55 +8,74 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2904064536553563204}
-  - component: {fileID: -6136489197034819759}
-  - component: {fileID: -1499766900028416198}
-  - component: {fileID: 6812364857601207734}
-  - component: {fileID: 7827061279219274638}
+  - component: {fileID: 8880797221330917285}
+  - component: {fileID: 3366211708096188460}
+  - component: {fileID: 1239617161806971552}
+  - component: {fileID: 48254275233714998}
+  - component: {fileID: 1737600228348484724}
+  - component: {fileID: 6813797106969371374}
+  - component: {fileID: 3305980863821901834}
   m_Layer: 0
-  m_Name: MonsterProjectile
-  m_TagString: Untagged
+  m_Name: TigerBoss
+  m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2904064536553563204
+--- !u!4 &8880797221330917285
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 128703109899176301}
+  m_GameObject: {fileID: 2355473164220929502}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 409.61874, y: 209.76323, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 3, y: 3, z: 0}
+  m_LocalScale: {x: 1.2, y: 1.2, z: 1.2}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &-6136489197034819759
+--- !u!114 &3366211708096188460
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 128703109899176301}
+  m_GameObject: {fileID: 2355473164220929502}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5e524858d37a31142a50756fe2b35295, type: 3}
+  m_Script: {fileID: 11500000, guid: 32c2ba6689cc5b54e9a08e1d1f3c2837, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 4
-  damage: 5
-  lifetime: 5
---- !u!212 &-1499766900028416198
+  maxHp: 100
+  moveSpeed: 1.2
+  contactDamage: 20
+  expOrbPrefab: {fileID: 622782962632113181, guid: e0f17047d092c564ba65b11d0ea8c20b, type: 3}
+  patternInterval: 5
+  patternWarningTime: 1
+  teleportDashSpeed: 10
+  teleportDashDistance: 6
+  fadeOutDuration: 0.2
+  fadeInDuration: 0.5
+  projectilePrefab: {fileID: 128703109899176301, guid: 206f4a7f6b9e9414a8c909c3499a36eb, type: 3}
+  projectileSpeed: 7
+  projectileSize: 1
+  projectileDamage: 10
+  barrageCount: 6
+  barrageInterval: 0.3
+  inertiaChaseMaxSpeed: 12
+  inertiaChaseAcceleration: 8
+  inertiaChaseRotationSpeed: 2
+  inertiaChaseDuration: 5
+--- !u!212 &1239617161806971552
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 128703109899176301}
+  m_GameObject: {fileID: 2355473164220929502}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -94,24 +113,24 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -1327499133, guid: 0d5e657ee5a074e4baa53d5b248a01d2, type: 3}
-  m_Color: {r: 0.06304721, g: 0.26951948, b: 0.9547169, a: 1}
-  m_FlipX: 0
+  m_Sprite: {fileID: 3515793568550062114, guid: 60da743a92524a74083609f4e4151a24, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 1
   m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.2777778, y: 0.5}
+  m_DrawMode: 1
+  m_Size: {x: 1, y: 1.2}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!58 &6812364857601207734
-CircleCollider2D:
+--- !u!61 &48254275233714998
+BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 128703109899176301}
+  m_GameObject: {fileID: 2355473164220929502}
   m_Enabled: 1
   serializedVersion: 3
   m_Density: 1
@@ -135,20 +154,30 @@ CircleCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
-  m_Radius: 0.25
---- !u!50 &7827061279219274638
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.34375, y: 1.8125}
+    newSize: {x: 1, y: 1.2}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 1
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!50 &1737600228348484724
 Rigidbody2D:
   serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 128703109899176301}
+  m_GameObject: {fileID: 2355473164220929502}
   m_BodyType: 1
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
@@ -156,7 +185,7 @@ Rigidbody2D:
   m_Mass: 1
   m_LinearDamping: 0
   m_AngularDamping: 0.05
-  m_GravityScale: 1
+  m_GravityScale: 0
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -167,4 +196,38 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
+--- !u!114 &6813797106969371374
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355473164220929502}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f94e73f83aa11bb4fa9084d8c777c3d9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!95 &3305980863821901834
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2355473164220929502}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 074f2c5e67e7d3f468d536c49ddeb9b7, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0

--- a/roguelike/Assets/02_Prefabs/Enemies/Bosses/TigerBoss.prefab.meta
+++ b/roguelike/Assets/02_Prefabs/Enemies/Bosses/TigerBoss.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4c707b92c025580468edb57d0563f09d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/roguelike/Assets/02_Prefabs/Enemies/Mobs/Enemy.prefab
+++ b/roguelike/Assets/02_Prefabs/Enemies/Mobs/Enemy.prefab
@@ -106,6 +106,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxHp: 10
   moveSpeed: 2
+  contactDamage: 5
   expOrbPrefab: {fileID: 622782962632113181, guid: e0f17047d092c564ba65b11d0ea8c20b, type: 3}
 --- !u!61 &48254275233714998
 BoxCollider2D:
@@ -137,7 +138,7 @@ BoxCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
@@ -165,7 +166,7 @@ Rigidbody2D:
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
-  m_Mass: 1
+  m_Mass: 1000
   m_LinearDamping: 0
   m_AngularDamping: 0.05
   m_GravityScale: 0

--- a/roguelike/Assets/02_Prefabs/Enemies/Mobs/RangedMonster.prefab
+++ b/roguelike/Assets/02_Prefabs/Enemies/Mobs/RangedMonster.prefab
@@ -50,8 +50,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxHp: 7
   moveSpeed: 1.5
+  contactDamage: 5
   expOrbPrefab: {fileID: 622782962632113181, guid: e0f17047d092c564ba65b11d0ea8c20b, type: 3}
-  attackRange: 3
+  attackRange: 5
   fireRate: 3
   projectilePrefab: {fileID: 128703109899176301, guid: 206f4a7f6b9e9414a8c909c3499a36eb, type: 3}
 --- !u!212 &1239617161806971552
@@ -167,7 +168,7 @@ Rigidbody2D:
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
-  m_Mass: 1
+  m_Mass: 1000
   m_LinearDamping: 0
   m_AngularDamping: 0.05
   m_GravityScale: 0

--- a/roguelike/Assets/02_Prefabs/Player/Player.prefab
+++ b/roguelike/Assets/02_Prefabs/Player/Player.prefab
@@ -118,7 +118,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!114 &6711421060320007765
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -145,6 +145,7 @@ MonoBehaviour:
     expMult: 1
     goldMult: 1
     damageReductionMult: 0
+  contactDamageCooldown: 0.5
 --- !u!58 &5670197590616524391
 CircleCollider2D:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
장산범 보스 추가
패턴 1 : 사라졌다가 플레이어 뒤에서 나타나 돌진
패턴 2 : 8방향으로 투사체 난사
패턴 3 : 빠른 속도로 플레이어 추격 (관성 적용)

Monster.cs / 몬스터 플레이어와 충돌 시 데미지 추가
PlayerManager.cs / 몬스터 충돌 시 무적시간 추가(1초)
Enemy.prefab / 충돌 시 날아가서 일단 무게를 올려놨습니다.
FoxBoss / 시각적 업데이트 및 보스 Kinematic으로 설정
MonsterProjectile, RangedMonster / 시각 업데이트 및 수치 조정 Player.prefab / 회전 안하게 고정