### PR TITLE
refactor: mainmenu 패널 매니저

### DIFF
--- a/roguelike/Assets/01_Scripts/UI/MainMenuPanelManager.cs
+++ b/roguelike/Assets/01_Scripts/UI/MainMenuPanelManager.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 /// <summary>
@@ -52,10 +53,9 @@ public class MainMenuPanelManager : MonoBehaviour
     /// </summary>
     public void HandleLobbyInput() // 이름 변경: ShowLobbyPanel -> HandleLobbyInput (Update에서 호출되므로)
     {
-        if (Input.anyKeyDown && mainPanel.activeSelf && !lobbyPanel.activeSelf)
+        if (Input.anyKeyDown && mainPanel.activeSelf)
         {
             mainPanel.SetActive(false);
-            lobbyPanel.SetActive(true);
         }
     }
 
@@ -84,6 +84,14 @@ public class MainMenuPanelManager : MonoBehaviour
     {
         AudioManager.Instance.PlaySfx(SFX_SELECT);
         codexPanel.SetActive(!codexPanel.activeSelf);
+    }
+
+
+        
+    //게임 시작 함수
+    public void Onclick_StartGame()
+    {
+        GameManager.Instance.StartGame();
     }
     #endregion
 


### PR DESCRIPTION
refactor: mainmenu 패널 매니저 처음입장시 로직 수정 및 게임 스타트 함수추가


메인메뉴화면에서 로비화면을 켠상태로 시작하고 게임스타트 버튼을 mainmenupanelmanger의 게임 시작 함수로 바꿔줘야함